### PR TITLE
remove entrypoint from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN apk update \
 	&& mkdir /srv
 RUN rm -f /var/cache/apk/*
 VOLUME ["/srv"]
-ENTRYPOINT /usr/bin/ruby
-CMD ["--version"]
+
+CMD ["/usr/bin/ruby", "--version"]


### PR DESCRIPTION
prevents you from running most commands like the normal way to run unicorn or even from running a shell.
