### PR TITLE
WIP: Use Ruby 2.4

### DIFF
--- a/rails-5/Dockerfile
+++ b/rails-5/Dockerfile
@@ -1,14 +1,25 @@
 FROM ruby:2.3-alpine
 MAINTAINER Greg Orlov <greg@avvo.com>
 
-RUN apk update && \
-    apk upgrade && \
-    apk add zlib-dev libxml2-dev libxslt-dev tzdata build-base linux-headers openssl-dev ca-certificates && \
-    apk add ruby-dev ruby-io-console ruby-json ruby-bigdecimal && \
-    update-ca-certificates && \
-    rm -rf /var/cache/apk/* && \
-    mkdir -p /srv && \
-    gem install --no-document bundler -v 1.12.5 && \
-    bundle config build.nokogiri --use-system-libraries
+RUN apk update \
+  && apk upgrade \
+  && apk add \
+    build-base \
+    ca-certificates
+    libxml2-dev \
+    libxslt-dev \
+    linux-headers \
+    openssl-dev \
+    ruby-bigdecimal \
+    ruby-dev \
+    ruby-io-console \
+    ruby-json \
+    tzdata \
+    zlib-dev \
+  && update-ca-certificates \
+  && rm -rf /var/cache/apk/* \
+  && mkdir -p /srv \
+  && gem install --no-document bundler -v 1.12.5 \
+  && bundle config build.nokogiri --use-system-libraries
 
 CMD ["/usr/bin/ruby", "--version"]

--- a/rails-5/Dockerfile
+++ b/rails-5/Dockerfile
@@ -5,21 +5,14 @@ RUN apk update \
   && apk upgrade \
   && apk add \
     build-base \
-    ca-certificates
-    libxml2-dev \
-    libxslt-dev \
-    linux-headers \
-    openssl-dev \
     ruby-bigdecimal \
     ruby-dev \
     ruby-io-console \
     ruby-json \
     tzdata \
-    zlib-dev \
   && update-ca-certificates \
   && rm -rf /var/cache/apk/* \
   && mkdir -p /srv \
-  && gem install --no-document bundler -v 1.12.5 \
   && bundle config build.nokogiri --use-system-libraries
 
 CMD ["/usr/bin/ruby", "--version"]

--- a/rails-5/Dockerfile
+++ b/rails-5/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.4-alpine
 MAINTAINER Greg Orlov <greg@avvo.com>
 
 RUN apk update \


### PR DESCRIPTION
Remove redundancies.

- [x] Can we remove `ruby-bigdecimal` from the `apk add` section? I think it is included/obsolete as of Ruby 2.4 integer unification.
- [ ] Can we remove any other packages from the `apk add` section?