### PR TITLE
Upgrading to latest alpine

### DIFF
--- a/rails-mysql/Dockerfile
+++ b/rails-mysql/Dockerfile
@@ -1,19 +1,14 @@
 FROM alpine
-MAINTAINER Jeff Ching <jching@avvo.com>
+MAINTAINER Avvo Infrastructure Team <infrastructure@avvo.com>
 
 RUN apk update && \
     apk upgrade && \
-    apk add zlib-dev libxml2-dev libxslt-dev tzdata build-base linux-headers openssl-dev ca-certificates && \
+    apk add mariadb-dev zlib-dev libxml2-dev libxslt-dev tzdata build-base linux-headers ca-certificates && \
     apk add ruby ruby-dev ruby-io-console ruby-json ruby-bigdecimal && \
     update-ca-certificates && \
-    rm -rf /var/cache/apk/* && \
     mkdir -p /srv && \
-    gem install --no-document bundler -v 1.12.5  && \
-    bundle config build.nokogiri --use-system-libraries
-
-RUN apk update && \
-    apk upgrade && \
-    apk add mysql-dev && \
+    gem install --no-document bundler -v 1.13.7  && \
+    bundle config build.nokogiri --use-system-libraries && \
     rm -rf /var/cache/apk/*
 
 CMD ["/usr/bin/ruby", "--version"]


### PR DESCRIPTION
Alpine apparently changed the version of openssl it installs, this uses the one most compatible with mariadb-dev by not even listing it as a dependency.